### PR TITLE
Switch to using easyocr

### DIFF
--- a/PillServicesPythonEnv/requirements.txt
+++ b/PillServicesPythonEnv/requirements.txt
@@ -3,7 +3,7 @@ torch>=1.13.0
 imutils==0.5.4
 numpy==1.21.6
 opencv-python-headless>=1.21.6
-keras-ocr==0.9.1
+easyocr==1.6.2
 tensorflow==2.11.0
 torchvision==0.13.1
 pillow==9.3.0


### PR DESCRIPTION
Modified OCR.py to use EasyOCR instead of keras-ocr, seems slightly more accurate, though full test is pending.  Updated requirements.txt accordingly.

I installed django locally and tried running the branch and it worked for me!  Since you already have PyTorch/torchvision installed for the other models, the only thing you should need to add to your local environment is easyocr.